### PR TITLE
Fix events firing twice after re-rendering dialog

### DIFF
--- a/src/aspects/instant-token-preview.js
+++ b/src/aspects/instant-token-preview.js
@@ -11,6 +11,7 @@
  */
 export function enableFor(app)
 {
+    app.element.off('input', onFormInput)
     app.element.on('input', onFormInput)
 }
 

--- a/src/utils/types.d.ts
+++ b/src/utils/types.d.ts
@@ -12,6 +12,7 @@ interface JQuery {
     after(newHtml: string): unknown
     closest(selector: string): JQuery
     find(selector: string): JQuery
+    off: JQuery['on']
     on<K extends keyof HTMLElementEventMap>(
         eventName: K,
         listener: (this: unknown, ev: HTMLElementEventMap[K]) => any): this;


### PR DESCRIPTION
This pull request makes `instantTokenPreview.enableFor` idempotent to fix a bug.